### PR TITLE
Resolve Oro 4.1.10 Compatibility Issue

### DIFF
--- a/src/Form/Extension/AbstractRecaptchaTypeExtension.php
+++ b/src/Form/Extension/AbstractRecaptchaTypeExtension.php
@@ -74,9 +74,9 @@ abstract class AbstractRecaptchaTypeExtension extends AbstractTypeExtension
      * @param $default
      * @return mixed
      */
-    protected function getConfiguration(string $key, $default)
+    protected function getConfiguration(string $key, $default = null)
     {
-        return $this->configManager->get(Configuration::getConfigKeyByName($key), $default);
+        return $this->configManager->get(Configuration::getConfigKeyByName($key)) ?? $default;
     }
 
     /**


### PR DESCRIPTION
`$default` parameter in `ConfigManager::getCacheKey()` is strict typehinted as a boolean in 4.1.10 onwards.
This release should be backwards compatible with previous versions of Oro 4.X