### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ This bundle supports the following Oro Platform versions:
 * Oro Platform v5.x
     - Support for this version is on the "v5.x" branch
 
+* Oro Platform v6.0.x
+    - Support for this version is on the "v6.0.x" branch
+
 The Master branch will always track support for the latest released Oro Platform version.
 
 Installation and Usage

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Oro Bundle to inject ReCAPTCHA into public forms",
     "type": "project",
     "require": {
-        "oro/platform": "5.1.*",
+        "oro/platform": "6.0.*",
         "excelwebzone/recaptcha-bundle": "^1.5"
     },
     "autoload": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,10 +25,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Generates the configuration tree builder.
-     *
-     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder(HackOroRecaptchaExtension::ALIAS);
         $rootNode = $treeBuilder->getRootNode();
@@ -41,20 +39,19 @@ class Configuration implements ConfigurationInterface
                 self::THEME => ['type' => 'scalar', 'value' => 'light'], // light/dark (default light)
                 self::SIZE => ['type' => 'scalar', 'value' => 'normal'], // normal/compact (default normal)
                 self::PROTECT_REGISTRATION => ['type' => 'boolean', 'value' => true],
-                self::PROTECT_CONTACT_FORM=> ['type' => 'boolean', 'value' => true],
+                self::PROTECT_CONTACT_FORM => ['type' => 'boolean', 'value' => true],
             ]
         );
         return $treeBuilder;
     }
 
-
-   /**
-         * Returns full key name by it's last part
-         *
-         * @param $name string last part of the key name (one of the class cons can be used)
-         * @return string full config path key
-         */
-        public static function getConfigKeyByName($name)
+    /**
+     * Returns full key name by it's last part
+     *
+     * @param $name string last part of the key name (one of the class cons can be used)
+     * @return string full config path key
+     */
+    public static function getConfigKeyByName(string $name): string
     {
         return HackOroRecaptchaExtension::ALIAS . ConfigManager::SECTION_MODEL_SEPARATOR . $name;
     }

--- a/src/DependencyInjection/HackOroRecaptchaExtension.php
+++ b/src/DependencyInjection/HackOroRecaptchaExtension.php
@@ -21,7 +21,7 @@ class HackOroRecaptchaExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Form/Extension/AbstractRecaptchaTypeExtension.php
+++ b/src/Form/Extension/AbstractRecaptchaTypeExtension.php
@@ -21,13 +21,11 @@ abstract class AbstractRecaptchaTypeExtension extends AbstractTypeExtension
     const DEFAULT_THEME = 'light';
     const DEFAULT_SIZE = 'normal';
 
-    /** @var ConfigManager */
-    protected $configManager;
+    protected ConfigManager $configManager;
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($this->isProtected()) {
-
             $builder->add('recaptcha', EWZRecaptchaType::class, [
                 'attr' => [
                     'options' => [
@@ -44,44 +42,28 @@ abstract class AbstractRecaptchaTypeExtension extends AbstractTypeExtension
         }
     }
 
-    /**
-     * @param ConfigManager $configManager
-     */
-    public function setConfigManager(ConfigManager $configManager)
+    public function setConfigManager(ConfigManager $configManager): void
     {
         $this->configManager = $configManager;
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getTheme()
+    protected function getTheme(): mixed
     {
         return $this->getConfiguration(Configuration::THEME, self::DEFAULT_THEME);
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getSize()
+    protected function getSize(): mixed
     {
         return $this->getConfiguration(Configuration::SIZE, self::DEFAULT_SIZE);
     }
 
     /**
      * Get configuration option
-     * @param string $key
-     * @param $default
-     * @return mixed
      */
-    protected function getConfiguration(string $key, $default = null)
+    protected function getConfiguration(string $key, mixed $default = null): mixed
     {
         return $this->configManager->get(Configuration::getConfigKeyByName($key)) ?? $default;
     }
 
-    /**
-     * @return boolean
-     */
-    abstract public function isProtected();
-
+    abstract public function isProtected(): bool;
 }

--- a/src/Form/Extension/ContactUsTypeExtension.php
+++ b/src/Form/Extension/ContactUsTypeExtension.php
@@ -14,16 +14,15 @@ use Oro\Bundle\ContactUsBundle\Form\Type\ContactRequestType;
 
 class ContactUsTypeExtension extends AbstractRecaptchaTypeExtension
 {
-    public function getExtendedType()
+    public function getExtendedType(): string
     {
         return ContactRequestType::class;
     }
 
     /**
      * Protect the Contact Us Form?
-     * @return boolean
      */
-    public function isProtected()
+    public function isProtected(): bool
     {
         return $this->getConfiguration(Configuration::PROTECT_CONTACT_FORM, false);
     }

--- a/src/Form/Extension/RegistrationTypeExtension.php
+++ b/src/Form/Extension/RegistrationTypeExtension.php
@@ -14,16 +14,15 @@ use Oro\Bundle\CustomerBundle\Form\Type\FrontendCustomerUserRegistrationType;
 
 class RegistrationTypeExtension extends AbstractRecaptchaTypeExtension
 {
-    public function getExtendedType()
+    public function getExtendedType(): string
     {
         return FrontendCustomerUserRegistrationType::class;
     }
 
     /**
      * Protect the Registration Form?
-     * @return boolean
      */
-    public function isProtected()
+    public function isProtected(): bool
     {
         return $this->getConfiguration(Configuration::PROTECT_REGISTRATION, false);
     }
@@ -35,5 +34,4 @@ class RegistrationTypeExtension extends AbstractRecaptchaTypeExtension
     {
         return [FrontendCustomerUserRegistrationType::class];
     }
-
 }


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Short list of done changes:
- Updated requirements to oro/platform 6.0.*
- Added return types/ type hints
- Deleted not needed annotations
- Added some CS fixes
- Updated README.md
